### PR TITLE
Tune Renovate grouping and dev web concurrency

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  // module.css 파일 커맨드 클릭 시, d.ts 파일때문에 바로가기가 안돼는 문제 해결 (TSX Definition Filter 플러그인 필요)
+  // module.css import 를 커맨드 클릭 시, d.ts 파일때문에 해당 module.css 파일로 바로가기가 안되는 문제 해결 (TSX Definition Filter 플러그인 필요)
   "tsxDefinitionFilter.remove": ["**/*/css-module.d.ts"],
   "files.exclude": {
     "**/.git": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "craft": "node inquirer.mjs && pnpm i",
     "dev": "pnpm ladle serve",
-    "dev:web": "turbo run watch",
+    "dev:web": "turbo run watch --concurrency=20",
     "build": "turbo run build",
     "build:ladle": "pnpm ladle build",
     "build:core": "pnpm --filter '@core/*' build && pnpm i",

--- a/packages/core/debug/src/usePane.ts
+++ b/packages/core/debug/src/usePane.ts
@@ -28,7 +28,6 @@ export type PaneProps<T extends Record<string, unknown>> = {
  *
  * ```
  */
-
 export const usePane = <Config extends Record<string, unknown>>({
   defaultConfig,
   ...paneProps

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,65 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "rangeStrategy": "bump",
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 8,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["/^@types\\//"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "type definitions"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "react dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["next", "@next/mdx", "@mdx-js/loader", "@mdx-js/react"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "next and mdx dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/postcss", "lightningcss"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "styling dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["typescript", "tsup", "turbo", "rimraf", "inquirer", "@biomejs/biome"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "tooling dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["gsap", "@gsap/react", "motion", "framer-motion"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "animation dependencies"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "es-toolkit",
+        "rxjs",
+        "usehooks-ts",
+        "clsx",
+        "tailwind-merge",
+        "zod",
+        "jotai",
+        "victor",
+        "react-hotkeys-hook"
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "utility dependencies"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- set Renovate rangeStrategy to bump so direct dependency ranges are updated instead of lockfile-only where possible
- group npm minor/patch updates by ecosystem: React, Next/MDX, styling, tooling, animation, utilities, and type definitions
- add Renovate PR rate limits and weekly lockfile maintenance
- fix pnpm dev:web by increasing Turbo watch concurrency for persistent tasks

## Notes
- Major updates are intentionally left ungrouped for easier review and rollback.
- pnpm dev:web now gets past Turbo's persistent task concurrency validation and starts the Next dev server.

## Verification
- node -e "JSON.parse(require('fs').readFileSync('renovate.json', 'utf8'))"
- pnpm exec biome check package.json renovate.json
- pnpm --package=renovate dlx renovate-config-validator renovate.json
- pnpm exec turbo run watch --concurrency=20 --dry=json
- pnpm dev:web (started successfully, then stopped after timeout because it is a persistent dev server)