### PR TITLE
Fix PieMenu animation scope

### DIFF
--- a/.ladle/FlickingGrid.tsx
+++ b/.ladle/FlickingGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface FlickeringGridProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/.ladle/ladle.css
+++ b/.ladle/ladle.css
@@ -1,34 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
-
-.space-mono-regular {
-  font-family: "Space Mono", monospace;
-  font-weight: 400;
-  font-style: normal;
-}
-
-.space-mono-bold {
-  font-family: "Space Mono", monospace;
-  font-weight: 700;
-  font-style: normal;
-}
-
-.space-mono-regular-italic {
-  font-family: "Space Mono", monospace;
-  font-weight: 400;
-  font-style: italic;
-}
-
-.space-mono-bold-italic {
-  font-family: "Space Mono", monospace;
-  font-weight: 700;
-  font-style: italic;
-}
-
-html {
-  font-family: "Space Mono", monospace;
-  font-weight: 400;
-}
-
 /* ladle 기본 UI 커스텀용  */
 .ladle-wrapper {
   flex-direction: row-reverse;
@@ -50,7 +19,7 @@ html {
   margin: 8px;
   padding-left: 1em !important;
   padding-top: 1em !important;
-  font-family: "Space Mono", monospace !important;
+
   font-weight: 400 !important;
 
   @media (max-width: 768px) {

--- a/packages/crafts/pie-menu/src/PieMenu.tsx
+++ b/packages/crafts/pie-menu/src/PieMenu.tsx
@@ -100,8 +100,6 @@ const CORE_WIDTH = 75;
 
 export const PieMenu = ({ onSelect }: PieMenuProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Keep track of the current crust angle
-  const crustAngleRef = useRef(0);
   const [activeSlotIdx, setActiveSlotIdx] = useState(0);
   const activeSlotIdxRef = useRef(0);
   const [show, setShow] = useState(false);
@@ -111,6 +109,7 @@ export const PieMenu = ({ onSelect }: PieMenuProps) => {
     if (typeof window === 'undefined' || !containerRef.current || !show) return;
 
     const center = getCenter(containerRef.current);
+    const setWrapperAngle = gsap.quickSetter(containerRef.current, '--a', 'deg');
     const onMouseMove = (event: MouseEvent) => {
       if ((event.target as HTMLElement).classList.contains('core')) {
         setActiveSlotIdx(-1);
@@ -122,7 +121,7 @@ export const PieMenu = ({ onSelect }: PieMenuProps) => {
       const vec = new Victor(clientX - center.x, center.y - clientY);
 
       const angle = vec.verticalAngleDeg();
-      gsap.quickSetter('.pie_menu_wrapper', '--a', 'deg')(angle);
+      setWrapperAngle(angle);
 
       const activeSlotIdx = getActiveSlotIdx(angle);
 
@@ -209,7 +208,7 @@ export const PieMenu = ({ onSelect }: PieMenuProps) => {
         '<',
       )
         .fromTo(
-          'li',
+          '.menu_item',
           {
             rotate: index => {
               return `${45 + index * 90 + 5}deg`;
@@ -250,6 +249,7 @@ export const PieMenu = ({ onSelect }: PieMenuProps) => {
     },
     {
       dependencies: [show],
+      scope: containerRef,
     },
   );
 

--- a/packages/crafts/pie-menu/src/pie_menu.css
+++ b/packages/crafts/pie-menu/src/pie_menu.css
@@ -28,12 +28,11 @@
 
 .mantle {
   position: relative;
-  /* inset: 0; */
   width: 100%;
   height: 100%;
-  /* overflow: hidden; */
   border-radius: inherit;
-  background: hsl(var(--primary-300) / 0.6);
+  background: color-mix(in oklch, var(--primary, oklch(0.55 0.16 260)) 24%, transparent);
+  border: 1px solid color-mix(in oklch, var(--primary, oklch(0.55 0.16 260)) 18%, transparent);
   box-shadow: inset -1px -1px 8px 0px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(12px);
 }
@@ -49,7 +48,7 @@
   transition: background 200ms;
 
   &[data-active="true"] {
-    background: hsl(var(--primary-200) / 0.3);
+    background: color-mix(in oklch, var(--primary, oklch(0.55 0.16 260)) 34%, transparent);
     cursor: url(/svg/mood-smile-active.svg) 8 8, auto;
     & > * {
       opacity: 1 !important;


### PR DESCRIPTION
## Summary
- scope PieMenu GSAP selectors to the PieMenu container so Ladle dock list items are not rotated
- replace the global wrapper quickSetter selector with the mounted wrapper element
- replace undefined primary-200/primary-300 CSS variables with theme-aware color-mix backgrounds

## Verification
- pnpm --filter @craft/pie-menu typecheck
- pnpm --filter @craft/pie-menu build
- pnpm exec biome check packages/crafts/pie-menu/src/PieMenu.tsx packages/crafts/pie-menu/src/pie_menu.css