### PR TITLE
Fix pnpm lockfile config mismatch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,8 @@ catalogs:
       specifier: ^3.1.1
       version: 3.1.1
 
+pnpmfileChecksum: ispnqhbvg4laq6ierkkioe35ku
+
 importers:
 
   .:
@@ -2764,7 +2766,7 @@ packages:
   react-inspector@6.0.2:
     resolution: {integrity: sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==}
     peerDependencies:
-      react: ^16.8.4 || ^17.0.0 || ^18.0.0
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}


### PR DESCRIPTION
## Summary
- regenerate pnpm-lock.yaml with the .pnpmfile.cjs checksum
- persist the react-inspector peer dependency override from .pnpmfile.cjs in the lockfile
- fix Vercel frozen install error: ERR_PNPM_LOCKFILE_CONFIG_MISMATCH

## Verification
- pnpm install --frozen-lockfile
- pnpm build