### PR TITLE
feat(table): add paired input paste preview

### DIFF
--- a/packages/crafts/table/package.json
+++ b/packages/crafts/table/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@craft/table",
+  "version": "1.0.0",
+  "description": "",
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "watch": "tsup --watch",
+    "build": "tsup",
+    "clean": "rimraf dist .turbo",
+    "clean:hard": "rimraf dist .turbo node_modules",
+    "typecheck": "tsc --noEmit",
+    "type": "tsc --emitDeclarationOnly --outDir dist"
+  },
+  "dependencies": {
+    "@utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19"
+  },
+  "devDependencies": {
+    "@core/debug": "workspace:*",
+    "@types/react": "catalog:react19",
+    "@types/react-dom": "catalog:react19"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/crafts/table/src/PairedInput.tsx
+++ b/packages/crafts/table/src/PairedInput.tsx
@@ -1,0 +1,36 @@
+import { type ReactNode, useState } from 'react';
+
+export type PairedInputValues = {
+  first: string;
+  second: string;
+};
+
+export type PairedInputSetValues = {
+  first: (value: string) => void;
+  second: (value: string) => void;
+};
+
+export type PairedInputRenderProps = {
+  values: PairedInputValues;
+  setValues: PairedInputSetValues;
+};
+
+export type PairedInputProps = {
+  children: (props: PairedInputRenderProps) => ReactNode;
+  defaultValues?: Partial<PairedInputValues>;
+};
+
+export const PairedInput = ({ children, defaultValues }: PairedInputProps) => {
+  const [values, setValues] = useState<PairedInputValues>(() => ({
+    first: defaultValues?.first ?? '',
+    second: defaultValues?.second ?? '',
+  }));
+
+  return children({
+    values,
+    setValues: {
+      first: value => setValues(prev => ({ ...prev, first: value })),
+      second: value => setValues(prev => ({ ...prev, second: value })),
+    },
+  });
+};

--- a/packages/crafts/table/src/Table.module.css
+++ b/packages/crafts/table/src/Table.module.css
@@ -1,0 +1,75 @@
+@import url("../../../core/theme/color.css");
+@import url("../../../core/theme/reset.css");
+@import url("https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400..500&display=swap");
+
+.container {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--table-border, var(--border, oklch(0.922 0 0)));
+  border-radius: var(--table-radius, var(--radius, 1rem));
+}
+
+.table {
+  width: 100%;
+  min-width: max-content;
+  caption-side: bottom;
+  border-collapse: collapse;
+  color: var(--table-foreground, var(--card-foreground, oklch(0.145 0 0)));
+  font-family: "Geist Mono", ui-monospace, "SF Mono", monospace;
+  font-size: var(--table-font-size, 0.875rem);
+  line-height: 1.5;
+}
+
+.header {
+  border-block-end: 1px solid var(--table-border, var(--border, oklch(0.922 0 0)));
+}
+
+.body .row:last-child {
+  border-block-end: 0;
+}
+
+.footer {
+  border-block-start: 1px solid var(--table-border, var(--border, oklch(0.922 0 0)));
+  background: var(--table-footer-background, var(--muted, oklch(0.97 0 0)));
+  font-weight: 500;
+}
+
+.footer .row:last-child {
+  border-block-end: 0;
+}
+
+.row {
+  border-block-end: 1px solid var(--table-border, var(--border, oklch(0.922 0 0)));
+  transition: background-color 120ms ease;
+}
+
+.row:hover {
+  background: var(--table-row-hover-background, color-mix(in oklch, var(--muted, oklch(0.97 0 0)) 72%, transparent));
+}
+
+.row[data-state="selected"],
+.row[data-selected="true"] {
+  background: var(--table-row-selected-background, var(--muted, oklch(0.97 0 0)));
+}
+
+.head {
+  height: var(--table-head-height, 3rem);
+  padding-block: 0.7rem;
+  padding-inline: var(--table-cell-x, 1rem);
+  color: var(--table-muted-foreground, var(--muted-foreground, oklch(0.556 0 0)));
+  text-align: start;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.cell {
+  padding-block: 0.5rem;
+  padding-inline: var(--table-cell-x, 1rem);
+  vertical-align: middle;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row {
+    transition: none;
+  }
+}

--- a/packages/crafts/table/src/Table.tsx
+++ b/packages/crafts/table/src/Table.tsx
@@ -1,0 +1,50 @@
+import { cn } from '@utils';
+import { type HTMLAttributes, type TdHTMLAttributes, type ThHTMLAttributes, forwardRef } from 'react';
+import styles from './Table.module.css';
+
+export type TableProps = HTMLAttributes<HTMLTableElement>;
+export type TableHeaderProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableBodyProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableFooterProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableRowProps = HTMLAttributes<HTMLTableRowElement>;
+export type TableHeadProps = ThHTMLAttributes<HTMLTableCellElement>;
+export type TableCellProps = TdHTMLAttributes<HTMLTableCellElement>;
+
+export const Table = forwardRef<HTMLTableElement, TableProps>(({ className, ...props }, ref) => {
+  return (
+    <div className={styles.container}>
+      <table ref={ref} className={cn(styles.table, className)} {...props} />
+    </div>
+  );
+});
+Table.displayName = 'Table';
+
+export const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>(({ className, ...props }, ref) => {
+  return <thead ref={ref} className={cn(styles.header, className)} {...props} />;
+});
+TableHeader.displayName = 'TableHeader';
+
+export const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(({ className, ...props }, ref) => {
+  return <tbody ref={ref} className={cn(styles.body, className)} {...props} />;
+});
+TableBody.displayName = 'TableBody';
+
+export const TableFooter = forwardRef<HTMLTableSectionElement, TableFooterProps>(({ className, ...props }, ref) => {
+  return <tfoot ref={ref} className={cn(styles.footer, className)} {...props} />;
+});
+TableFooter.displayName = 'TableFooter';
+
+export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(({ className, ...props }, ref) => {
+  return <tr ref={ref} className={cn(styles.row, className)} {...props} />;
+});
+TableRow.displayName = 'TableRow';
+
+export const TableHead = forwardRef<HTMLTableCellElement, TableHeadProps>(({ className, ...props }, ref) => {
+  return <th ref={ref} className={cn(styles.head, className)} {...props} />;
+});
+TableHead.displayName = 'TableHead';
+
+export const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(({ className, ...props }, ref) => {
+  return <td ref={ref} className={cn(styles.cell, className)} {...props} />;
+});
+TableCell.displayName = 'TableCell';

--- a/packages/crafts/table/src/index.ts
+++ b/packages/crafts/table/src/index.ts
@@ -1,0 +1,24 @@
+export {
+  PairedInput,
+  type PairedInputProps,
+  type PairedInputRenderProps,
+  type PairedInputSetValues,
+  type PairedInputValues,
+} from './PairedInput';
+
+export {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+  type TableBodyProps,
+  type TableCellProps,
+  type TableFooterProps,
+  type TableHeadProps,
+  type TableHeaderProps,
+  type TableProps,
+  type TableRowProps,
+} from './Table';

--- a/packages/crafts/table/stories/Table.stories.module.css
+++ b/packages/crafts/table/stories/Table.stories.module.css
@@ -1,0 +1,112 @@
+.input {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 4px 7px;
+  outline: 0;
+  font-family: var(--font-mono);
+  color: var(--foreground);
+  font-size: 12px;
+  background-color: var(--background);
+  width: 100%;
+}
+
+.input:focus-visible {
+  border-color: var(--ring, oklch(0.708 0 0));
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.708 0 0)) 20%, transparent);
+}
+
+.commandInputGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.commandInputGroup .input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.primaryButton,
+.cancelButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  height: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  padding-inline: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease, box-shadow 120ms ease, color 120ms ease;
+}
+
+.primaryButton {
+  --button-background: oklch(0.623 0.214 259.815);
+
+  color: var(--primary-foreground, oklch(0.985 0 0));
+  background: var(--button-background);
+  border-color: var(--button-background);
+}
+
+.primaryButton:hover {
+  background: color-mix(in oklch, var(--button-background) 88%, black);
+}
+
+.cancelButton {
+  color: var(--foreground);
+  background: var(--background);
+}
+
+.cancelButton:hover {
+  background: var(--muted, oklch(0.97 0 0));
+}
+
+.primaryButton:focus-visible,
+.cancelButton:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.708 0 0)) 35%, transparent);
+}
+
+.iconButton {
+  flex: 0 0 auto;
+  width: 2rem;
+  padding-inline: 0;
+  font-size: 1rem;
+}
+
+.previewSummary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--muted-foreground, oklch(0.556 0 0));
+  font-size: 0.75rem;
+}
+
+.previewRow {
+  background: color-mix(in oklch, var(--primary, oklch(0.205 0 0)) 5%, transparent);
+}
+
+.previewAliasName,
+.previewCommand {
+  color: var(--muted-foreground, oklch(0.556 0 0));
+  font-style: italic;
+}
+
+.previewSkippedRow {
+  color: var(--destructive, oklch(0.577 0.245 27.325));
+  font-size: 0.75rem;
+}
+
+.previewActions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/packages/crafts/table/stories/Table.stories.tsx
+++ b/packages/crafts/table/stories/Table.stories.tsx
@@ -1,0 +1,229 @@
+import type { Story } from '@ladle/react';
+import { useState } from 'react';
+import { PairedInput, Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow } from '../src';
+import styles from './Table.stories.module.css';
+
+type Alias = {
+  name: string;
+  command: string;
+};
+
+type AliasPreview = {
+  items: Alias[];
+  skippedLines: string[];
+};
+
+const initialAliases: Alias[] = [
+  {
+    name: 'gst',
+    command: 'git status',
+  },
+  {
+    name: 'gco',
+    command: 'git checkout',
+  },
+  {
+    name: 'll',
+    command: 'eza -la --git',
+  },
+  {
+    name: 'k',
+    command: 'kubectl',
+  },
+  {
+    name: 'py',
+    command: 'python3',
+  },
+];
+
+const stripOuterQuotes = (value: string) => {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+
+  if ((quote === '"' || quote === "'") && trimmed[trimmed.length - 1] === quote) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+};
+
+const parseAliasLine = (line: string): Alias | null => {
+  const parts = line.split('=');
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const name = stripOuterQuotes(parts[0]);
+  const command = stripOuterQuotes(parts[1]);
+
+  if (!name || !command) {
+    return null;
+  }
+
+  return { name, command };
+};
+
+const parseAliasPaste = (text: string): AliasPreview => {
+  const lines = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  return lines.reduce<AliasPreview>(
+    (result, line) => {
+      const alias = parseAliasLine(line);
+
+      if (alias) {
+        result.items.push(alias);
+      } else {
+        result.skippedLines.push(line);
+      }
+
+      return result;
+    },
+    { items: [], skippedLines: [] },
+  );
+};
+
+export const Default: Story = () => {
+  const [aliases, setAliases] = useState(initialAliases);
+  const [preview, setPreview] = useState<AliasPreview | null>(null);
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className={styles.visuallyHidden}>
+          <TableHead>Alias name</TableHead>
+          <TableHead>Command</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {aliases.map((alias, index) => (
+          <TableRow key={`${alias.name}-${index}`}>
+            <TableCell style={{ width: '250px', color: 'oklch(0.623 0.214 259.815)' }} className={styles.aliasName}>
+              {alias.name}
+            </TableCell>
+            <TableCell className={styles.command}>{alias.command}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter className={styles.formFooter}>
+        {preview && (
+          <>
+            <TableRow className={styles.previewSummaryRow}>
+              <TableCell colSpan={2}>
+                <div className={styles.previewSummary}>
+                  <span>{preview.items.length} aliases detected</span>
+                  {preview.skippedLines.length > 0 && <span>{preview.skippedLines.length} lines skipped</span>}
+                </div>
+              </TableCell>
+            </TableRow>
+            {preview.items.map((alias, index) => (
+              <TableRow key={`${alias.name}-${index}`} className={styles.previewRow}>
+                <TableCell className={styles.previewAliasName}>{alias.name}</TableCell>
+                <TableCell className={styles.previewCommand}>{alias.command}</TableCell>
+              </TableRow>
+            ))}
+            {preview.skippedLines.length > 0 && (
+              <TableRow className={styles.previewSkippedRow}>
+                <TableCell colSpan={2}>Skipped: {preview.skippedLines.join(', ')}</TableCell>
+              </TableRow>
+            )}
+            <TableRow className={styles.previewActionRow}>
+              <TableCell colSpan={2}>
+                <div className={styles.previewActions}>
+                  <button
+                    className={styles.primaryButton}
+                    type='button'
+                    onClick={() => {
+                      setAliases(prev => [...prev, ...preview.items]);
+                      setPreview(null);
+                    }}
+                  >
+                    Add {preview.items.length} aliases
+                  </button>
+                  <button className={styles.cancelButton} type='button' onClick={() => setPreview(null)}>
+                    Cancel
+                  </button>
+                </div>
+              </TableCell>
+            </TableRow>
+          </>
+        )}
+        <PairedInput>
+          {({ values, setValues }) => (
+            <TableRow className={styles.formRow}>
+              <TableCell className={styles.aliasInputCell}>
+                <input
+                  value={values.first}
+                  onPaste={e => {
+                    const text = e.clipboardData.getData('text');
+                    const lines = text
+                      .split(/\r?\n/)
+                      .map(line => line.trim())
+                      .filter(Boolean);
+
+                    if (lines.length > 1) {
+                      const nextPreview = parseAliasPaste(text);
+
+                      if (nextPreview.items.length > 0) {
+                        e.preventDefault();
+                        setPreview(nextPreview);
+                        return;
+                      }
+                    }
+
+                    const parts = text.split('=');
+
+                    if (parts.length === 2) {
+                      e.preventDefault();
+                      setPreview(null);
+                      setValues.first(stripOuterQuotes(parts[0]));
+                      setValues.second(stripOuterQuotes(parts[1]));
+                    }
+                  }}
+                  onChange={e => setValues.first(e.target.value)}
+                  className={styles.input}
+                  placeholder='alias name'
+                  aria-label='Alias name'
+                />
+              </TableCell>
+              <TableCell>
+                <div className={styles.commandInputGroup}>
+                  <input
+                    value={values.second}
+                    onChange={e => setValues.second(e.target.value)}
+                    className={styles.input}
+                    placeholder='command'
+                    aria-label='Command'
+                  />
+                  <button
+                    className={`${styles.primaryButton} ${styles.iconButton}`}
+                    type='button'
+                    aria-label='Add alias'
+                    onClick={() => {
+                      const name = values.first.trim();
+                      const command = values.second.trim();
+
+                      if (!name || !command) {
+                        return;
+                      }
+
+                      setAliases(prev => [...prev, { name, command }]);
+                      setValues.first('');
+                      setValues.second('');
+                      setPreview(null);
+                    }}
+                  >
+                    +
+                  </button>
+                </div>
+              </TableCell>
+            </TableRow>
+          )}
+        </PairedInput>
+      </TableFooter>
+    </Table>
+  );
+};

--- a/packages/crafts/table/stories/tsconfig.json
+++ b/packages/crafts/table/stories/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "moduleResolution": "bundler"
+  },
+  "include": ["*.ts", "*.tsx", "../src", "../../../../css-module.d.ts"]
+}

--- a/packages/crafts/table/tsconfig.json
+++ b/packages/crafts/table/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "module": "NodeNext",
+    "moduleResolution": "node16"
+  },
+  "include": ["src", "index.ts", "../../../css-module.d.ts"]
+}

--- a/packages/crafts/table/tsup.config.ts
+++ b/packages/crafts/table/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig(options => ({
+  entry: ['src/index.ts'],
+  dts: true,
+  clean: true,
+  minify: !options.watch,
+  target: 'es2022',
+  format: ['esm'],
+  banner: { js: '"use client";' },
+  loader: {
+    '.css': 'copy',
+  },
+  external: ['react', 'react-dom'],
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,28 @@ importers:
         specifier: catalog:react19
         version: 19.1.3(@types/react@19.1.3)
 
+  packages/crafts/table:
+    dependencies:
+      '@utils':
+        specifier: workspace:*
+        version: link:../../utils
+      react:
+        specifier: catalog:react19
+        version: 19.1.0
+      react-dom:
+        specifier: catalog:react19
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@core/debug':
+        specifier: workspace:*
+        version: link:../../core/debug
+      '@types/react':
+        specifier: catalog:react19
+        version: 19.1.3
+      '@types/react-dom':
+        specifier: catalog:react19
+        version: 19.1.3(@types/react@19.1.3)
+
   packages/crafts/tanos-input:
     dependencies:
       react:


### PR DESCRIPTION
## Summary
- add the @craft/table package exports and PairedInput render-props helper
- wire the table story inputs through PairedInput
- support single-line alias paste and multi-line alias preview with Add/Cancel actions
- style the add button as a compact shadcn-like inline button

## Test
- pnpm --filter @craft/table typecheck